### PR TITLE
Add support for generating lockfiles to rpmtree

### DIFF
--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"os"
 
 	"github.com/bazelbuild/buildtools/build"
@@ -137,10 +136,6 @@ func NewRpmTreeCmd() *cobra.Command {
 		Short: "Writes a rpmtree rule and its rpmdependencies to bazel files",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, required []string) error {
-			if rpmtreeopts.toMacro != "" && rpmtreeopts.lockfile != "" {
-				return errors.New("Must provide at most one of --lockfile --to-macro")
-			}
-
 			repos, err := repo.LoadRepoFiles(rpmtreeopts.repofiles)
 			if err != nil {
 				return err
@@ -173,9 +168,12 @@ func NewRpmTreeCmd() *cobra.Command {
 			}
 
 			var handler Handler
+			var configname string
+
 			if rpmtreeopts.toMacro != "" {
 				handler, err = NewMacroHandler(rpmtreeopts.toMacro)
 			} else if rpmtreeopts.lockfile != "" {
+				configname = rpmtreeopts.configname
 				handler, err = NewLockFileHandler(
 					rpmtreeopts.configname,
 					rpmtreeopts.lockfile,
@@ -198,7 +196,7 @@ func NewRpmTreeCmd() *cobra.Command {
 				return err
 			}
 
-			bazel.AddTree(rpmtreeopts.name, rpmtreeopts.configname, build, install, rpmtreeopts.arch, rpmtreeopts.public)
+			bazel.AddTree(rpmtreeopts.name, configname, build, install, rpmtreeopts.arch, rpmtreeopts.public)
 
 			handler.PruneRPMs(build)
 			logrus.Info("Writing bazel files.")

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/rmohr/bazeldnf/cmd/template"
 	"github.com/rmohr/bazeldnf/pkg/api"
+	"github.com/rmohr/bazeldnf/pkg/api/bazeldnf"
 	"github.com/rmohr/bazeldnf/pkg/bazel"
 	"github.com/rmohr/bazeldnf/pkg/reducer"
 	"github.com/rmohr/bazeldnf/pkg/repo"
@@ -23,6 +25,8 @@ type rpmtreeOpts struct {
 	workspace        string
 	toMacro          string
 	buildfile        string
+	configname       string
+	lockfile         string
 	name             string
 	public           bool
 	forceIgnoreRegex []string
@@ -84,7 +88,7 @@ func NewWorkspaceHandler(workspace string) (Handler, error) {
 	}
 
 	return &WorkspaceHandler{
-		workspace: workspace,
+		workspace:     workspace,
 		workspacefile: workspacefile,
 	}, nil
 }
@@ -101,6 +105,31 @@ func (h *WorkspaceHandler) Write() error {
 	return bazel.WriteWorkspace(false, h.workspacefile, h.workspace)
 }
 
+type LockFileHandler struct {
+	filename string
+	config   *bazeldnf.Config
+}
+
+func NewLockFileHandler(configname, filename string) (Handler, error) {
+	return &LockFileHandler{
+		filename: filename,
+		config: &bazeldnf.Config{
+			Name: configname,
+			RPMs: []bazeldnf.RPM{},
+		},
+	}, nil
+}
+
+func (h *LockFileHandler) AddRPMs(pkgs []*api.Package, arch string) error {
+	return bazel.AddConfigRPMs(h.config, pkgs, arch)
+}
+
+func (h *LockFileHandler) PruneRPMs(buildfile *build.File) {}
+
+func (h *LockFileHandler) Write() error {
+	return bazel.WriteLockFile(h.config, h.filename)
+}
+
 func NewRpmTreeCmd() *cobra.Command {
 
 	rpmtreeCmd := &cobra.Command{
@@ -108,7 +137,9 @@ func NewRpmTreeCmd() *cobra.Command {
 		Short: "Writes a rpmtree rule and its rpmdependencies to bazel files",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, required []string) error {
-			writeToMacro := rpmtreeopts.toMacro != ""
+			if rpmtreeopts.toMacro != "" && rpmtreeopts.lockfile != "" {
+				return errors.New("Must provide at most one of --lockfile --to-macro")
+			}
 
 			repos, err := repo.LoadRepoFiles(rpmtreeopts.repofiles)
 			if err != nil {
@@ -142,16 +173,21 @@ func NewRpmTreeCmd() *cobra.Command {
 			}
 
 			var handler Handler
-			if writeToMacro {
+			if rpmtreeopts.toMacro != "" {
 				handler, err = NewMacroHandler(rpmtreeopts.toMacro)
+			} else if rpmtreeopts.lockfile != "" {
+				handler, err = NewLockFileHandler(
+					rpmtreeopts.configname,
+					rpmtreeopts.lockfile,
+				)
 			} else {
 				handler, err = NewWorkspaceHandler(rpmtreeopts.workspace)
 			}
-			
+
 			if err != nil {
 				return err
 			}
-			
+
 			build, err := bazel.LoadBuild(rpmtreeopts.buildfile)
 			if err != nil {
 				return err
@@ -162,8 +198,8 @@ func NewRpmTreeCmd() *cobra.Command {
 				return err
 			}
 
-			bazel.AddTree(rpmtreeopts.name, build, install, rpmtreeopts.arch, rpmtreeopts.public)
-			
+			bazel.AddTree(rpmtreeopts.name, rpmtreeopts.configname, build, install, rpmtreeopts.arch, rpmtreeopts.public)
+
 			handler.PruneRPMs(build)
 			logrus.Info("Writing bazel files.")
 			err = handler.Write()
@@ -191,6 +227,8 @@ func NewRpmTreeCmd() *cobra.Command {
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.workspace, "workspace", "w", "WORKSPACE", "Bazel workspace file")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.toMacro, "to-macro", "", "", "Tells bazeldnf to write the RPMs to a macro in the given bzl file instead of the WORKSPACE file. The expected format is: macroFile%defName")
 	rpmtreeCmd.Flags().StringVarP(&rpmtreeopts.buildfile, "buildfile", "b", "rpm/BUILD.bazel", "Build file for RPMs")
+	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.configname, "configname", "rpms", "config name to use in lockfile")
+	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.lockfile, "lockfile", "", "lockfile for RPMs")
 	rpmtreeCmd.Flags().StringVar(&rpmtreeopts.name, "name", "", "rpmtree rule name")
 	rpmtreeCmd.Flags().StringArrayVar(&rpmtreeopts.forceIgnoreRegex, "force-ignore-with-dependencies", []string{}, "Packages matching these regex patterns will not be installed. Allows force-removing unwanted dependencies. Be careful, this can lead to hidden missing dependencies.")
 	rpmtreeCmd.MarkFlagRequired("name")

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -123,7 +123,9 @@ func (h *LockFileHandler) AddRPMs(pkgs []*api.Package, arch string) error {
 	return bazel.AddConfigRPMs(h.config, pkgs, arch)
 }
 
-func (h *LockFileHandler) PruneRPMs(buildfile *build.File) {}
+func (h *LockFileHandler) PruneRPMs(buildfile *build.File) {
+	// we always generate from scratch and have nothing to prune
+}
 
 func (h *LockFileHandler) Write() error {
 	return bazel.WriteLockFile(h.config, h.filename)

--- a/cmd/rpmtree.go
+++ b/cmd/rpmtree.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/rmohr/bazeldnf/cmd/template"
+	"github.com/rmohr/bazeldnf/pkg/api"
 	"github.com/rmohr/bazeldnf/pkg/bazel"
 	"github.com/rmohr/bazeldnf/pkg/reducer"
 	"github.com/rmohr/bazeldnf/pkg/repo"
@@ -28,6 +29,77 @@ type rpmtreeOpts struct {
 }
 
 var rpmtreeopts = rpmtreeOpts{}
+
+type Handler interface {
+	AddRPMs(pkgs []*api.Package, arch string) error
+	PruneRPMs(buildfile *build.File)
+	Write() error
+}
+
+type MacroHandler struct {
+	bzl, defName string
+	bzlfile      *build.File
+}
+
+func NewMacroHandler(toMacro string) (Handler, error) {
+	bzl, defName, err := bazel.ParseMacro(rpmtreeopts.toMacro)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bzlfile, err := bazel.LoadBzl(bzl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MacroHandler{
+		bzl:     bzl,
+		bzlfile: bzlfile,
+		defName: defName,
+	}, nil
+}
+
+func (h *MacroHandler) AddRPMs(pkgs []*api.Package, arch string) error {
+	return bazel.AddBzlfileRPMs(h.bzlfile, h.defName, pkgs, arch)
+}
+
+func (h *MacroHandler) PruneRPMs(buildfile *build.File) {
+	bazel.PruneBzlfileRPMs(buildfile, h.bzlfile, h.defName)
+}
+
+func (h *MacroHandler) Write() error {
+	return bazel.WriteBzl(false, h.bzlfile, h.bzl)
+}
+
+type WorkspaceHandler struct {
+	workspace     string
+	workspacefile *build.File
+}
+
+func NewWorkspaceHandler(workspace string) (Handler, error) {
+	workspacefile, err := bazel.LoadWorkspace(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkspaceHandler{
+		workspace: workspace,
+		workspacefile: workspacefile,
+	}, nil
+}
+
+func (h *WorkspaceHandler) AddRPMs(pkgs []*api.Package, arch string) error {
+	return bazel.AddWorkspaceRPMs(h.workspacefile, pkgs, arch)
+}
+
+func (h *WorkspaceHandler) PruneRPMs(buildfile *build.File) {
+	bazel.PruneWorkspaceRPMs(buildfile, h.workspacefile)
+}
+
+func (h *WorkspaceHandler) Write() error {
+	return bazel.WriteWorkspace(false, h.workspacefile, h.workspace)
+}
 
 func NewRpmTreeCmd() *cobra.Command {
 
@@ -68,54 +140,37 @@ func NewRpmTreeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			workspace, err := bazel.LoadWorkspace(rpmtreeopts.workspace)
+
+			var handler Handler
+			if writeToMacro {
+				handler, err = NewMacroHandler(rpmtreeopts.toMacro)
+			} else {
+				handler, err = NewWorkspaceHandler(rpmtreeopts.workspace)
+			}
+			
 			if err != nil {
 				return err
 			}
-			var bzlfile *build.File
-			var bzl, defName string
-			if writeToMacro {
-				bzl, defName, err = bazel.ParseMacro(rpmtreeopts.toMacro)
-				if err != nil {
-					return err
-				}
-				bzlfile, err = bazel.LoadBzl(bzl)
-				if err != nil {
-					return err
-				}
-			}
+			
 			build, err := bazel.LoadBuild(rpmtreeopts.buildfile)
 			if err != nil {
 				return err
 			}
-			if writeToMacro {
-				err = bazel.AddBzlfileRPMs(bzlfile, defName, install, rpmtreeopts.arch)
-				if err != nil {
-					return err
-				}
-			} else {
-				err = bazel.AddWorkspaceRPMs(workspace, install, rpmtreeopts.arch)
-				if err != nil {
-					return err
-				}
-			}
-			bazel.AddTree(rpmtreeopts.name, build, install, rpmtreeopts.arch, rpmtreeopts.public)
-			if writeToMacro {
-				bazel.PruneBzlfileRPMs(build, bzlfile, defName)
-			} else {
-				bazel.PruneWorkspaceRPMs(build, workspace)
-			}
-			logrus.Info("Writing bazel files.")
-			err = bazel.WriteWorkspace(false, workspace, rpmtreeopts.workspace)
+
+			err = handler.AddRPMs(install, rpmtreeopts.arch)
 			if err != nil {
 				return err
 			}
-			if writeToMacro {
-				err = bazel.WriteBzl(false, bzlfile, bzl)
-				if err != nil {
-					return err
-				}
+
+			bazel.AddTree(rpmtreeopts.name, build, install, rpmtreeopts.arch, rpmtreeopts.public)
+			
+			handler.PruneRPMs(build)
+			logrus.Info("Writing bazel files.")
+			err = handler.Write()
+			if err != nil {
+				return err
 			}
+
 			err = bazel.WriteBuild(false, build, rpmtreeopts.buildfile)
 			if err != nil {
 				return err

--- a/pkg/api/bazeldnf/BUILD.bazel
+++ b/pkg/api/bazeldnf/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "bazeldnf",
-    srcs = ["repo.go"],
+    srcs = [
+        "config.go",
+        "repo.go",
+    ],
     importpath = "github.com/rmohr/bazeldnf/pkg/api/bazeldnf",
     visibility = ["//visibility:public"],
 )

--- a/pkg/api/bazeldnf/config.go
+++ b/pkg/api/bazeldnf/config.go
@@ -1,0 +1,12 @@
+package bazeldnf
+
+type RPM struct {
+	Name string `json:"name"`
+	SHA256 string `json:"sha256"`
+	URLs []string `json:"urls"`
+}
+
+type Config struct {
+	Name string `json:"name"`
+	RPMs []RPM `json:"rpms"`
+}

--- a/pkg/bazel/BUILD.bazel
+++ b/pkg/bazel/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api",
+        "//pkg/api/bazeldnf",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_bazelbuild_buildtools//edit:go_default_library",
     ],

--- a/pkg/bazel/bazel_test.go
+++ b/pkg/bazel/bazel_test.go
@@ -115,7 +115,7 @@ func TestBuildfileWithRPMs(t *testing.T) {
 			defer os.Remove(tmpFile.Name())
 			file, err := LoadBuild(tt.orig)
 			g.Expect(err).ToNot(HaveOccurred())
-			AddTree("mytree", file, tt.pkgs, "myarch", false)
+			AddTree("mytree", "", file, tt.pkgs, "myarch", false)
 			err = WriteBuild(false, file, tmpFile.Name())
 			g.Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This change introduces the necessary bits for producing lockfiles using rpmtree in lieu of having to hand craft them. It also tweaks the rpmtree() invocation in the BUILD file so that it correctly points at the lockfile derived repos.